### PR TITLE
Change wildfly deploy dir to one which is actually used.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM jboss/wildfly
-ADD node-info.war /opt/wildfly/standalone/deployments/
+ADD node-info.war /opt/jboss/wildfly/standalone/deployments/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This example shows how to deploy a war file using the [`jboss/wildfly` Docker im
 1. Create `Dockerfile` with following content:
 
         FROM jboss/wildfly
-        ADD node-info.war /opt/wildfly/standalone/deployments/
+        ADD node-info.war /opt/jboss/wildfly/standalone/deployments/
 2. Place your `node-info.war` file in the same directory as your `Dockerfile`.
 3. Run the build with `docker build --tag=wildfly-app .`
 4. Run the container with `docker run -it -p 8080:8080 wildfly-app`. Application will be deployed on the container boot.
@@ -26,7 +26,7 @@ $ docker run -it wildfly-app
 
   JBoss Bootstrap Environment
 
-  JBOSS_HOME: /opt/wildfly
+  JBOSS_HOME: /opt/jboss/wildfly
 
   JAVA: java
 


### PR DESCRIPTION
Hey! I was toying around with Widfly docker image and I was using your example to get into the swing of things. 

Alas I was not having any luck with deploying the application. jboss/wildfly image from docker hub uses `/opt/jboss/wildfly/` directory for WildFly application and not `/opt/wildfly` as you specified in your example which is a bit misleading.

I bash'ed inside the running container and inspected it for myself. This is a screenshot with application correctly deployed and working! :8ball: 
![image](https://cloud.githubusercontent.com/assets/7034331/19182506/cb570018-8c73-11e6-8ba8-a1eee0597eea.png)
